### PR TITLE
Update config.plist

### DIFF
--- a/EFI on OpenCore/OC/config.plist
+++ b/EFI on OpenCore/OC/config.plist
@@ -668,7 +668,7 @@
 	<key>Misc</key>
 	<dict>
 		<key>BlessOverride</key>
-		<dict/>
+		<array/>
 		<key>Boot</key>
 		<dict>
 			<key>ConsoleAttributes</key>
@@ -729,7 +729,7 @@
 			<key>BootProtect</key>
 			<string>None</string>
 			<key>ExposeSensitiveData</key>
-			<string>14</string>
+			<integer>6</integer>
 			<key>HaltLevel</key>
 			<integer>2147483648</integer>
 			<key>ScanPolicy</key>


### PR DESCRIPTION
FIx some error messages during boot 
* BlessOverride type
* OCS: Failed to parse string field of type 1